### PR TITLE
Rename GHCR container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Push image
         run: |
-          IMAGE_ID=ghcr.io/${{ github.repository }}/imdb-trakt-sync
+          IMAGE_ID=ghcr.io/${{ github.repository }}
 
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           [ "$VERSION" == "master" ] && VERSION=latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,6 +39,7 @@ jobs:
 
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           [ "$VERSION" == "master" ] && VERSION=latest
+          [ "$VERSION" == "main" ] && VERSION=latest
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ version: "3"
 services:
   imdb_trakt_sync:
     restart: always
-    image: ghcr.io/josh/imdb-trakt-sync/imdb-trakt-sync
+    image: ghcr.io/josh/imdb-trakt-sync
     environment:
       - IMDB_UBID_MAIN=***
       - IMDB_AT_MAIN=***


### PR DESCRIPTION
Heads up @jpbaril @alaq

I didn't realize a new feature of the ghcr.io change was that packages are now pushed to the user namespace rather than repository. As a result, we can just name the container without the duplicate repo name. The new image name will just be `ghcr.io/josh/imdb-trakt-sync`

🍻 