### PR TITLE
Pin GitHub Actions to full-length SHAs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,9 @@ jobs:
       RUFF_OUTPUT_FORMAT: github
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5
 
       - name: Install dependencies
         run: uv sync
@@ -34,9 +34,9 @@ jobs:
       UV_RESOLUTION: ${{ matrix.uv_resolution }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
 
       - name: Enable auto-merge
         if: steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major'

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -12,9 +12,9 @@ jobs:
 
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/trakt.yml
+++ b/.github/workflows/trakt.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-slim
 
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-token
         with:
           app-id: ${{ vars.GH_APP_ID }}


### PR DESCRIPTION
## Summary
- pin workflow actions to the provided full-length commit SHAs
- include version comments to preserve Dependabot visibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939ba211c38832692f126a8de201a6a)