### PR TITLE
Fix Trakt token refresh workflow

### DIFF
--- a/.github/workflows/trakt.yml
+++ b/.github/workflows/trakt.yml
@@ -13,18 +13,34 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.GH_APP_ID }}
+          client-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Refresh Trakt token
         run: |
-          curl --silent --fail \
-              -X POST \
-              -F "client_id=$TRAKT_CLIENT_ID" \
-              -F "client_secret=$TRAKT_CLIENT_SECRET" \
-              -F "refresh_token=$TRAKT_REFRESH_TOKEN" \
-              -F "grant_type=refresh_token" \
-            'https://api.trakt.tv/oauth/token' >token.json
+          status=$(curl --silent --show-error \
+              --request POST \
+              --header 'Content-Type: application/json' \
+              --output token.json \
+              --write-out '%{http_code}' \
+              --data @- \
+              'https://api.trakt.tv/oauth/token' <<EOF
+          {
+            "client_id": "$TRAKT_CLIENT_ID",
+            "client_secret": "$TRAKT_CLIENT_SECRET",
+            "refresh_token": "$TRAKT_REFRESH_TOKEN",
+            "grant_type": "refresh_token"
+          }
+          EOF
+          )
+
+          if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+            echo "Trakt token refresh failed with HTTP $status" >&2
+            jq --raw-output '.error_description // .error // .' token.json >&2
+            exit 1
+          fi
+
+          jq --exit-status '.access_token and .refresh_token' token.json >/dev/null
         env:
           TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
           TRAKT_CLIENT_SECRET: ${{ secrets.TRAKT_CLIENT_SECRET }}


### PR DESCRIPTION
### Motivation
- The workflow emitted a deprecation warning for `app-id` and the Trakt refresh `curl` step failed with non‑2xx responses (exit code 22), so the refresh logic needed to be more robust. 
- Improve error visibility and fail-fast behavior when the Trakt API returns an error or a response missing the expected tokens. 

### Description
- Replace the deprecated `app-id` input with `client-id` for the `actions/create-github-app-token` step. 
- Replace the multipart `curl -F` request with a JSON POST using `--data @-` and capture the HTTP status with `--write-out '%{http_code}'` while saving the response to `token.json`. 
- Add an explicit HTTP status check that prints Trakt API error text via `jq` and exits non‑zero on non‑2xx responses, and validate that both `access_token` and `refresh_token` exist before updating GitHub secrets. 

### Testing
- Parsed all workflows successfully with Ruby YAML loader using `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "parsed #{f}" }'`, which succeeded. 
- Extracted and inspected the `run` block of the updated workflow and verified shell syntax with `bash -n`, which succeeded. 
- Verified `git diff --check` returned no whitespace or patch problems, which succeeded. 
- A Python `yaml` parse attempt failed due to the environment missing the `PyYAML` module (automated check failure unrelated to the workflow content).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58364f93f083268e08765f028338bd)